### PR TITLE
aiming to improve static grounding behavior for cells directly next to each other

### DIFF
--- a/abc/action-MPP.ilp
+++ b/abc/action-MPP.ilp
@@ -4,7 +4,8 @@
 
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 #program step(t).
 

--- a/abc/action-MPP.lp
+++ b/abc/action-MPP.lp
@@ -4,7 +4,8 @@
 time(1..horizon).
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 
 

--- a/abc/state.lp
+++ b/abc/state.lp
@@ -4,7 +4,8 @@
 time(1..horizon).
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 { position(R,C,T) } :- isRobot(R), position(C), time(T).
 { position(S,C,T) } :- isShelf(S), position(C), time(T).

--- a/control/holes.lp
+++ b/control/holes.lp
@@ -4,7 +4,8 @@
 
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C,D,C')                    :- tonext(C,D,C'), position(C').
 
 % hole(C) :- highway(C), #count { C' : nextto(C,D,C'), highway(C'), direction(D) } > 2.
 hole(C) :- highway(C), nextto(C,(X',Y'),C'), highway(C'), nextto(C,(X'',Y''),C''), highway(C''), X'*X''+Y'*Y''=0.

--- a/control/zone.lp
+++ b/control/zone.lp
@@ -3,8 +3,9 @@
 #const max=1.
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto(N,N') :-      node(N,(X,Y)),     node(N',(X+X',Y+Y')), direction((X',Y')),
-                not highway((X,Y)), not highway((X+X',Y+Y')).
+tonext(N,(X+X',Y+Y')) :- node(N,(X,Y)), direction((X',Y')),
+                    not highway((X,Y)), not highway((X+X',Y+Y')).
+nextto(N,N')          :- tonext(N,C'), node(N',C').
 
 node(N,C) :- init(object(node,N), value(at,C)).
 node(N) :- node(N,_).

--- a/legacy/action-MPP-2.ilp
+++ b/legacy/action-MPP-2.ilp
@@ -5,7 +5,8 @@
 
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 #program step(t).
 

--- a/legacy/action-MPP-2.lp
+++ b/legacy/action-MPP-2.lp
@@ -4,7 +4,8 @@
 time(1..horizon).
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 
 

--- a/m/action-M.ilp
+++ b/m/action-M.ilp
@@ -5,7 +5,8 @@
 
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 #program step(t).
 

--- a/m/action-M.lp
+++ b/m/action-M.lp
@@ -4,7 +4,8 @@
 time(1..horizon).
 
 direction((X,Y)) :- X=-1..1, Y=-1..1, |X+Y|=1.
-nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).
+tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
+nextto(C',D,C)                    :- tonext(C',D,C), position(C).
 
 { move(R,D,T) : direction(D) } 1 :- isRobot(R), time(T).
 


### PR DESCRIPTION
With an AAU master student, we tried simple versions of the asprilo encodings for large MAPF instances and noted that a static rule like

`nextto((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')), position((X+X',Y+Y')).`

shows extremely bad grounding behavior of clingo, and that splitting it into two rules

```
tonext((X,Y),(X',Y'),(X+X',Y+Y')) :- position((X,Y)), direction((X',Y')).
nextto(C',D,C)                    :- tonext(C',D,C), position(C).
```

works much better. The changes in this pull request aim to improve the grounding behavior.